### PR TITLE
add beta to control decrease rate seperately

### DIFF
--- a/ema_test.go
+++ b/ema_test.go
@@ -17,6 +17,20 @@ func TestEMA(t *testing.T) {
 	assert.EqualValues(t, 19, e.Get())
 	assert.EqualValues(t, 28.9, e.UpdateDuration(30))
 	assert.EqualValues(t, 28.9, e.GetDuration().Nanoseconds())
+	assert.EqualValues(t, 5, e.UpdateDuration(3), "Should decrese quickly with a large alpha")
+}
+
+func TestEMAWithBeta(t *testing.T) {
+	defaultValue := float64(1.1235235)
+	e := NewWithBeta(defaultValue, 0.9, 0.1)
+	assert.EqualValues(t, defaultValue, e.Get(), "Should return default value before it's been set")
+	assert.EqualValues(t, 10, e.Update(10), "First update should simply set value")
+	assert.EqualValues(t, 10, e.Get())
+	assert.EqualValues(t, 19, e.Update(20), "Second update should factor into moving average")
+	assert.EqualValues(t, 19, e.Get())
+	assert.EqualValues(t, 28.9, e.UpdateDuration(30))
+	assert.EqualValues(t, 28.9, e.GetDuration().Nanoseconds())
+	assert.EqualValues(t, 26, e.UpdateDuration(3), "Should decrese slowly with a small beta")
 }
 
 func TestBinaryValue(t *testing.T) {


### PR DESCRIPTION
For https://github.com/getlantern/config-server/pull/160 to have a global EMA with separate rate of increase and decrease.